### PR TITLE
Add language specifiers to markdown codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All information regarding Project Setup, Technical Details, Tests and informatio
 
 ## Install
 
-```
+```shell
 $ npm i @alaskaairux/ods-button
 ```
 
@@ -32,19 +32,19 @@ CSS Custom Properties are not supported in older browsers. For this, fallback pr
 
 Define the component dependency within each component that is using the \<ods-button> component.
 
-```
+```javascript
 import "@alaskaairux/ods-button/ods-button";
 ```
 
 **Reference component in HTML**
 
-```
+```html
 <ods-button>Hello World</ods-button>
 ```
 
 ## Element \<ods-button>
 
-```
+```javascript
 class OdsButton extends LitElement
 ```
 
@@ -94,37 +94,37 @@ The \<ods-button> element will respond without context settings as expected. Wit
 
 Default button
 
-```
+```html
 <ods-button>Hello World</ods-button>
 ```
 
 Default button with disabled state set to `true`
 
-```
+```html
 <ods-button disabled>hello world</ods-button>
 ```
 
 Default button with active state set to `true`
 
-```
+```html
 <ods-button isactive>hello world</ods-button>
 ```
 
 Secondary button
 
-```
+```html
 <ods-button buttontype="secondary">hello world</ods-button>
 ```
 
 Secondary button with disabled state set to `true`
 
-```
+```html
 <ods-button buttontype="secondary" disabled>hello world</ods-button>
 ```
 
 Secondary button with active state set to `true`
 
-```
+```html
 <ods-button active buttontype="secondary">hello world</ods-button>
 ```
 
@@ -134,7 +134,7 @@ A special case scenario for responsiveness. The \<ods-button> element is built t
 
 In this scenario, simply set the `context` of the element to be `true`.
 
-```
+```html
 <ods-button string="Default state; context true" context="true"></ods-button>
 ```
 
@@ -162,7 +162,7 @@ Within the respective directories are two files, `style.css` and `style_clean.sc
 
 These files can be imported directly into the scope of your project's CSS. It is highly recommended that you use the `style_clean.scss` file and import this into a name-space as not to create style collisions. For example:
 
-```
+```scss
 .ods-button {
   @import "./node_modules/@alaskaairux/ods-button/altImportsCanonical/style_clean.scss";
 }
@@ -170,7 +170,7 @@ These files can be imported directly into the scope of your project's CSS. It is
 
 This pattern will produce all the selectors within `style_clean.scss` with the prefixed selector.
 
-```
+```scss
 .ods-button .button {
   display: var(--ods-button-display);
   font-family: var(--ods-button-font-family);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Example code can be dull to look at without syntax highlighting, so this PR adds language specifiers to code blocks in an effort to improve README readability.

## Summary:

Before this PR, code blocks were quite dull and void of color
![image](https://user-images.githubusercontent.com/14362200/57088381-06c68800-6cb7-11e9-98f3-d7d8b9cfc812.png)

After this PR, code blocks are vibrant and more readable as they more closely resemble the code editor colors that a developer uses everyday
![image](https://user-images.githubusercontent.com/14362200/57088437-1e057580-6cb7-11e9-8b97-a265857fe883.png)


## Type of change:

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
