### PR TITLE
Submit form on click by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The \<ods-button> element will respond without context settings as expected. Wit
 | condensed | boolean | Reduces left/right padding to fit button in condensed spaces |
 | disabled | boolean | If set to true button will become disabled and not allow for interactions. <br/>Default value is `false`. |
 | flowtype | string | Sets display type to represent the flow options. Options: `complete`
-| form | string | The form element that the button is associated with (its form owner). The value of the attribute must be the id attribute of a `<form>` element in the same document |
+| form | string | The form element that the button is associated with (its form owner). The value of the attribute must be the id attribute of a `<form>` element in the same document. If defined, clicking the button will submit the form with the given ID by default. |
 | formaction | string | Specifies the URL of the file that will process the input control when the form is submitted. The formaction attribute overrides the `action` attribute of the `<form>` element |
 | formenctype| string | If the button is a submit button, this attribute specifies the type of content that is used to submit the form to the server. |
 | formmethod | string | If the button is a submit button, this attribute specifies the HTTP method that the browser uses to submit the form. |

--- a/src/ods-button.js
+++ b/src/ods-button.js
@@ -92,7 +92,20 @@ class OdsButton extends LitElement {
   }
 
   buttonCallback() {
-    console.log('Alert: Event not bound to button')
+    if (this.form) {
+      this.formSubmitCallback(this.form);
+    } else {
+      console.log('Alert: Event not bound to button');
+    }    
+  }
+
+  formSubmitCallback(formId) {
+    let formElement = document.getElementById(formId);
+    if (formElement) {
+      formElement.submit();
+    } else {
+      console.log(`Alert: Form with ID "${formId}" does not exist`);
+    }
   }
 
   render() {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Update the default click event when the form property is provided.

## Summary:

This update changes the default click event when the form property is provided. Before this change, the button would log to the console by default when clicked. With this change, the button will attempt to submit the form with the given id when the form property is provided. If the form property is not provided, the button will continue to log to the console. This supports a common button use-case (submitting a form) without the developer needing to wire up the submit.

## Type of change:

- [x] New capability 
- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
