### PR TITLE
BREAKING CHANGE: Removed 'buttonCallback' prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,15 +184,6 @@ In addition, using the `ods-containedButtons--reverse` selector will move the la
 <ods-button disabled buttontype="secondary" theme="classic">disabled classic secondary</ods-button>
 ```
 
-
-### Custom callbacks
-
-Button(React support) with `ref` for passing in an event, [see notes](https://github.com/AlaskaAirlines/OrionStatelessComponents__docs/blob/master/docs/CALLBACK.md)
-
-```html
-<ods-button ref={this.event}>hello world</ods-button>
-```
-
 ### Contextual component
 
 A special case scenario for responsiveness. The \<ods-button> element is built to handle responsive situations when it is the only element within a block. If the \<ods-button> element is used within context of another element, then it's the responsibility of the parent element to dictate the responsiveness of the \<ods-element>.

--- a/demo/index.html
+++ b/demo/index.html
@@ -173,12 +173,25 @@
           <ods-button id="change-button" buttontype="secondary" >Change Message</ods-button>
           <script>
             const mbutton = document.querySelector('#message-button');
-            mbutton.buttonCallback = () => alert('Hello!');
+            const originalHandler = () => alert('Hello!');
+            mbutton.addEventListener('click', originalHandler);
 
             const cbutton = document.querySelector('#change-button');
-            cbutton.buttonCallback = () => {
-              mbutton.buttonCallback = () => alert('goodbye!');
-            }
+            cbutton.addEventListener('click', () => {
+              mbutton.removeEventListener('click', originalHandler, false);
+              mbutton.addEventListener('click', () => alert('goodbye!'));
+            });
+          </script>
+        </template>
+      </demo-snippet>
+
+      <demo-snippet>
+        <template>
+          <ods-button id="message-button-2" disabled>Click For Message</ods-button>
+          <script>
+            const mbutton2 = document.querySelector('#message-button-2');
+            const originalHandler2 = () => alert('Hello!');
+            mbutton2.addEventListener('click', originalHandler2);
           </script>
         </template>
       </demo-snippet>

--- a/src/ods-button.js
+++ b/src/ods-button.js
@@ -53,7 +53,6 @@ class OdsButton extends LitElement {
       title:            { type: String },
       type:             { type: String },
       value:            { type: String },
-      buttonCallback:   { type: Function }
     };
   }
 
@@ -92,9 +91,6 @@ class OdsButton extends LitElement {
     return disabled || isactive;
   }
 
-  buttonCallback() {
-    console.log('Alert: Event not bound to button')
-  }
 
   render() {
     return html`
@@ -127,14 +123,13 @@ class OdsButton extends LitElement {
         title="${ifDefined(this.title ? this.title : undefined)}"
         name="${ifDefined(this.name ? this.name : undefined)}"
         part="button--modifier"
-        @click=${() => this.buttonCallback()}
         type="${ifDefined(this.type ? this.type : undefined)}"
         .value="${ifDefined(this.value ? this.value : undefined)}"
       >
 
         ${ifDefined(this.svgIconLeft ? this.getIcon(this.svgIconLeft) : undefined)}
-
-        <slot></slot>
+        <!--Slot still clickabled when button disabled for some reason-->
+        <slot @click=${e => {if(this.disabled) e.stopPropagation()}}></slot>
 
         ${ifDefined(this.svgIconRight ? this.getIcon(this.svgIconRight) : undefined)}
 

--- a/src/ods-button.js
+++ b/src/ods-button.js
@@ -128,8 +128,7 @@ class OdsButton extends LitElement {
       >
 
         ${ifDefined(this.svgIconLeft ? this.getIcon(this.svgIconLeft) : undefined)}
-        <!--Slot still clickabled when button disabled for some reason-->
-        <slot @click=${e => {if(this.disabled) e.stopPropagation()}}></slot>
+        <slot></slot>
 
         ${ifDefined(this.svgIconRight ? this.getIcon(this.svgIconRight) : undefined)}
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -52,6 +52,10 @@
   }
 }
 
+slot {
+  pointer-events: none;
+}
+
 // layout
 svg {
   vertical-align: var(--svg-vertical-align);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Removed `buttonCallback` in favor of more standard event listener. 

## Summary:

The `buttonCallback` prop was initially added due to the button still being clickable even when disabled when using the more traditional click event listener. This feature was causing users to have to build wrappers in React to be able to set the prop and get click events to bind to the element. During investigation it seems the reason the clicks where still firing on disabled buttons was due to a chrome specific bug related to `slot` tag content. Normal content in disabled buttons don't propagate clicks, but it seems that's not the case for `slot` tags in just google chrome. That being discovered a conditional click propagation has been added to the `slot` based on disabled status. 

This fix now renders the `buttonCallback` unnecessary and any `react` wrappers created for the button excessive. 

## Type of change:

- Removed `buttonCallback` prop
- fixed `slot` content firing click event when button disabled
- Updated docs
- Updated demo so that this functionality can be tested
- Updated demo to use standard `addEventListener` syntax instead of `buttonCallback`

- [ ] New capability 
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate) 


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
