### PR TITLE
fix: allow button to be clicked in React with IE11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/ods-button",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/component-base.js
+++ b/src/component-base.js
@@ -123,6 +123,8 @@ export default class ComponentBase extends LitElement {
         part="button--modifier"
         type="${ifDefined(this.type ? this.type : undefined)}"
         .value="${ifDefined(this.value ? this.value : undefined)}"
+
+        @click="${() => {}}"
       >
 
         ${ifDefined(this.svgIconLeft ? this.getIcon(this.svgIconLeft) : undefined)}


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Summary:

When used in a React application in IE11, the button was not responding to clicks. Adding a no-op click handler on the button within the component fixed the issue and does not appear to have any negative side effects in a non-React environment.

Tested on Polymer demo page and in OrionReactDemo in Firefox, Chrome, and IE11.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
