### PR TITLE
fix: recognize if a custom element has already been registered

### DIFF
--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -18,4 +18,6 @@ class AuroButton extends AuroComponentBase {
   }
 }
 
-customElements.define("auro-button", AuroButton);
+if (!customElements.get("auro-button")) {
+  customElements.define("auro-button", AuroButton);
+}

--- a/src/ods-button.js
+++ b/src/ods-button.js
@@ -22,4 +22,6 @@ class OdsButton extends ComponentBase {
   }
 }
 
-customElements.define("ods-button", OdsButton);
+if (!customElements.get("ods-button")) {
+  customElements.define("ods-button", OdsButton);
+}


### PR DESCRIPTION
# Alaska Airlines Pull Request

When pulling in multiple externally-sourced custom elements in the same page that references other Auro components, those Auro components are being registered as custom elements multiple times which causes runtime errors in the consuming project.

## Summary:

To prevent multiple of the same custom elements from being defined, we search the currently registered custom elements for existing instances. If an instance of that element exists, we do not define the element.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
